### PR TITLE
Prevent rotation when only with one item

### DIFF
--- a/src/jquery.quote_rotator.js
+++ b/src/jquery.quote_rotator.js
@@ -27,7 +27,7 @@
   $.fn.extend({
     quote_rotator: function(config) {
       
-      var config = $.extend({}, $.quote_rotator.defaults, config);
+      config = $.extend({}, $.quote_rotator.defaults, config);
       
       return this.each(function() {
         var rotation;
@@ -49,7 +49,7 @@
               quote_list.find('li:first').addClass('active');
           }
         }();
-        
+
         var get_next_quote = function(quote) {
           return quote.next('li').length ? quote.next('li') : quote_list.find('li:first');
         }

--- a/src/jquery.quote_rotator.js
+++ b/src/jquery.quote_rotator.js
@@ -35,7 +35,11 @@
         var list_items = quote_list.find('li');
         var rotation_active = true;
         var rotation_speed = config.rotation_speed < 2000 ? 2000 : config.rotation_speed;
-        
+
+        if(list_items.length <= 1) {
+          return;
+        }
+
         var add_active_class = function() {
           var active_class_not_already_applied = quote_list.find('li.active').length === 0;
           if (config.randomize_first_quote) {


### PR DESCRIPTION
I can't really see much of a case for wanting the quote animation to occur when you only have one, so I am suggesting that we check for the number of items first and prevent rotation if there is one or less.

That var on line 30 also was just unnecessarily redeclaring the parameter variable. 
